### PR TITLE
Add favicon and apple touch icons

### DIFF
--- a/books/nastavnik-18-primer/index.html
+++ b/books/nastavnik-18-primer/index.html
@@ -8,6 +8,8 @@
   <meta property="og:title" content="НАСТАВНИК 18 — Пример" />
   <meta property="og:description" content="" />
   <meta property="og:image" content="img/hero-wide.jpg" />
+  <link rel="icon" href="../../favicon.ico" />
+  <link rel="apple-touch-icon" href="../../apple-touch-icon.png" />
   <link rel="stylesheet" href="../../assets/css/base.css" />
 </head>
 <body data-page="book-landing" data-meta="./book.json" data-slug="nastavnik-18-primer">

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     <meta property="og:title" content="Книги Виталика — каталог" />
     <meta property="og:description" content="Онлайн-библиотека Виталика: книги серии НАСТАВНИК и другие проекты." />
     <meta property="og:image" content="assets/img/cover-placeholder.jpg" />
+    <link rel="icon" href="favicon.ico" />
+    <link rel="apple-touch-icon" href="apple-touch-icon.png" />
     <link rel="stylesheet" href="assets/css/base.css" />
 </head>
 


### PR DESCRIPTION
## Summary
- Link favicon and apple-touch icons in main catalog page
- Link favicon and apple-touch icons in book landing page
- Remove apple-touch icon file so you can supply your own

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b86c7b49fc83289e561c139c599697